### PR TITLE
feat: fix workspace member not getting bumped issue

### DIFF
--- a/lazy-attribute/Cargo.toml
+++ b/lazy-attribute/Cargo.toml
@@ -17,7 +17,7 @@ doctest = true
 
 [dependencies]
 async-once-cell = { version = "0.5", optional = true }
-lazy-attribute-core = { version = "0.1.1", path = "../lazy-attribute-core" }
+lazy-attribute-core = { version = "0.1.2", path = "../lazy-attribute-core" }
 once_cell = "1.18"
 
 [dev-dependencies]

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "plugins": [],
+  "plugins": ["cargo-workspace"],
   "changelog-path": "CHANGELOG.md",
   "release-type": "rust",
   "bump-minor-pre-major": true,


### PR DESCRIPTION
# Description

Release please did not update `lazy-attribute` to point to the right `lazy-attribute-core` version. Fixing that with "cargo-workspace" plugin.